### PR TITLE
Sub-oscillator pitch is now a parameter.

### DIFF
--- a/lib/Engine_Icarus.sc
+++ b/lib/Engine_Icarus.sc
@@ -17,14 +17,14 @@ Engine_Icarus : CroneEngine {
 		(0..5).do({arg i; 
 			SynthDef("icarussynth"++i,{ 
 				arg amp=0.5, hz=220, pan=0, envgate=0,
-				pulse=0,saw=0,bend=0,
+				pulse=0,saw=0,bend=0,subpitch=1,
 				attack=0.015,decay=1,release=2,sustain=0.9,
 				lpf=20000,resonance=0,portamento=0.1,tremelo=0,destruction=0,
 				pwmcenter=0.5,pwmwidth=0.05,pwmfreq=10,detuning=0.1,
 				feedback=0.5,delaytime=0.25, delaytimelag=0.1, sublevel=0;
 
 				// vars
-				var ender,snd,local,in,ampcheck,hz_dream,hz_sub;
+				var ender,snd,local,in,ampcheck,hz_dream,hz_sub,subdiv;
 
 				// envelope stuff
 				ender = EnvGen.ar(
@@ -45,7 +45,8 @@ Engine_Icarus : CroneEngine {
 					mul:0.5
 				);
 				// add suboscillator
-				hz_sub=(Lag.kr(hz/2+(SinOsc.kr(LFNoise0.kr(1))*(((hz/2).cpsmidi+1).midicps-(hz/2))*detuning),portamento).cpsmidi + bend).midicps;
+				subdiv=2**subpitch;
+				hz_sub=(Lag.kr(hz/subdiv+(SinOsc.kr(LFNoise0.kr(1))*(((hz/subdiv).cpsmidi+1).midicps-(hz/subdiv))*detuning),portamento).cpsmidi + bend).midicps;
 				in = in + Pulse.ar(hz_sub,
 					width:
 					LFTri.kr(pwmfreq+rrand(0.1,0.3),mul:pwmwidth/2,add:pwmcenter),
@@ -253,6 +254,11 @@ Engine_Icarus : CroneEngine {
 		this.addCommand("bend","f", { arg msg;
 			(0..5).do({arg i;
 				icarusPlayer[i].set(\bend,msg[1]);
+			});
+		});
+		this.addCommand("subpitch","f", { arg msg;
+			(0..5).do({arg i;
+				icarusPlayer[i].set(\subpitch,msg[1]);
 			});
 		});
 

--- a/lib/icarus.lua
+++ b/lib/icarus.lua
@@ -25,7 +25,7 @@ function Icarus:new(args)
 
   local debounce_delaytime=0
 
-  params:add_group("ICARUS",19)
+  params:add_group("ICARUS",20)
   local filter_freq=controlspec.new(40,18000,'exp',0,18000,'Hz')
   params:add_option("polyphony","polyphony",{"monophonic","polyphonic"},2)
   params:add {
@@ -59,6 +59,14 @@ function Icarus:new(args)
   controlspec=controlspec.new(0,2,'lin',0,0.5,'amp',0.01/2)}
   params:set_action("sub",function(v)
     engine.sub(v)
+  end)
+  params:add {
+    type='control',
+    id="subpitch",
+    name="sub pitch",
+  controlspec=controlspec.new(0,3,'lin',0.01,1,'oct',-0.003333)}
+  params:set_action("subpitch",function(v)
+    engine.subpitch(v)
   end)
   params:add {
     type='control',


### PR DESCRIPTION
Value is defined by the parameter `sub pitch` which sets the sub-oscillator octave (in relation to the main oscillator).
Default value is 1 octave below, which mimics the original behaviour. The range is between 3 and 0 octaves below the main oscillator (0 octaves means that it has the same frequency).